### PR TITLE
Replace hardcoded Kindle-specific paths with variables

### DIFF
--- a/kindlefetch/bin/downloads/lgli_download.sh
+++ b/kindlefetch/bin/downloads/lgli_download.sh
@@ -3,12 +3,12 @@
 lgli_download() {
     local index=$1
     
-    if [ ! -f "/tmp/search_results.json" ]; then
+    if [ ! -f "$TMP_DIR/search_results.json" ]; then
         echo "Error: No search results found" >&2
         return 1
     fi
     
-    local book_info=$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' /tmp/search_results.json)
+    local book_info=$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' $TMP_DIR/search_results.json)
     if [ -z "$book_info" ]; then
         echo "Error: Invalid book selection" >&2
         return 1

--- a/kindlefetch/bin/downloads/zlib_download.sh
+++ b/kindlefetch/bin/downloads/zlib_download.sh
@@ -3,12 +3,12 @@
 zlib_download() {
     local index=$1
     
-    if [ ! -f "/tmp/search_results.json" ]; then
+    if [ ! -f "$TMP_DIR/search_results.json" ]; then
         echo "Error: No search results found" >&2
         return 1
     fi
     
-    local book_info=$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' /tmp/search_results.json)
+    local book_info=$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' $TMP_DIR/search_results.json)
     if [ -z "$book_info" ]; then
         echo "Error: Invalid book selection" >&2
         return 1

--- a/kindlefetch/bin/kindlefetch.sh
+++ b/kindlefetch/bin/kindlefetch.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 CONFIG_FILE="$SCRIPT_DIR/kindlefetch_config"
 LINK_CONFIG_FILE="$SCRIPT_DIR/link_config"
 VERSION_FILE="$SCRIPT_DIR/.version"
+TMP_DIR="/tmp"
+BASE_DIR="/mnt/us"
 
 UPDATE_AVAILABLE=false
 

--- a/kindlefetch/bin/kindlefetch.sh
+++ b/kindlefetch/bin/kindlefetch.sh
@@ -10,7 +10,7 @@ CONFIG_FILE="$SCRIPT_DIR/kindlefetch_config"
 LINK_CONFIG_FILE="$SCRIPT_DIR/link_config"
 VERSION_FILE="$SCRIPT_DIR/.version"
 TMP_DIR="/tmp"
-BASE_DIR="$BASE_DIR"
+BASE_DIR="/mnt/us"
 
 UPDATE_AVAILABLE=false
 

--- a/kindlefetch/bin/kindlefetch.sh
+++ b/kindlefetch/bin/kindlefetch.sh
@@ -10,12 +10,12 @@ CONFIG_FILE="$SCRIPT_DIR/kindlefetch_config"
 LINK_CONFIG_FILE="$SCRIPT_DIR/link_config"
 VERSION_FILE="$SCRIPT_DIR/.version"
 TMP_DIR="/tmp"
-BASE_DIR="/mnt/us"
+BASE_DIR="$BASE_DIR"
 
 UPDATE_AVAILABLE=false
 
 # Check if running on a Kindle
-if ! { [ -f "/etc/prettyversion.txt" ] || [ -d "/mnt/us" ] || pgrep "lipc-daemon" >/dev/null; }; then
+if ! { [ -f "/etc/prettyversion.txt" ] || [ -d "$BASE_DIR" ] || pgrep "lipc-daemon" >/dev/null; }; then
     echo "Error: This script must run on a Kindle device." >&2
     echo "Press any key to exit."
     read -n 1 -s

--- a/kindlefetch/bin/local_books.sh
+++ b/kindlefetch/bin/local_books.sh
@@ -2,7 +2,7 @@
 
 delete_book() {
     index=$1
-    book_file=$(sed -n "${index}p" /tmp/kindle_books.list 2>/dev/null)
+    book_file=$(sed -n "${index}p" $TMP_DIR/kindle_books.list 2>/dev/null)
     
     if [ -z "$book_file" ]; then
         echo "Invalid selection"
@@ -24,7 +24,7 @@ delete_book() {
 
 delete_directory() {
     index=$1
-    dir_path=$(sed -n "${index}p" /tmp/kindle_folders.list 2>/dev/null)
+    dir_path=$(sed -n "${index}p" $TMP_DIR/kindle_folders.list 2>/dev/null)
     
     if [ -z "$dir_path" ]; then
         echo "Invalid selection"
@@ -61,8 +61,8 @@ list_local_books() {
         echo ""
         
         i=1
-        > /tmp/kindle_books.list
-        > /tmp/kindle_folders.list
+        > $TMP_DIR/kindle_books.list
+        > $TMP_DIR/kindle_folders.list
 
         if [ ! -d "$current_dir" ]; then
             echo "Error: Directory '$current_dir' does not exist."
@@ -73,7 +73,7 @@ list_local_books() {
             if [ -d "$item" ]; then
                 foldername=$(basename "$item")
                 echo "$i. $foldername/"
-                echo "$item" >> /tmp/kindle_folders.list
+                echo "$item" >> $TMP_DIR/kindle_folders.list
                 i=$((i+1))
             fi
         done
@@ -83,7 +83,7 @@ list_local_books() {
                 filename=$(basename "$item")
                 extension="${filename##*.}"
                 echo "$i. $filename"
-                echo "$item" >> /tmp/kindle_books.list
+                echo "$item" >> $TMP_DIR/kindle_books.list
                 i=$((i+1))
             fi
         done
@@ -100,7 +100,7 @@ list_local_books() {
         echo "q: Back to main menu"
         echo ""
 
-        total_items=$(( $(wc -l < /tmp/kindle_folders.list 2>/dev/null) + $(wc -l < /tmp/kindle_books.list 2>/dev/null) ))
+        total_items=$(( $(wc -l < $TMP_DIR/kindle_folders.list 2>/dev/null) + $(wc -l < $TMP_DIR/kindle_books.list 2>/dev/null) ))
         
         echo -n "Enter choice: "
         read choice
@@ -116,7 +116,7 @@ list_local_books() {
                 echo -n "Enter directory number to delete: "
                 read dir_num
                 if echo "$dir_num" | grep -qE '^[0-9]+$'; then
-                    if [ "$dir_num" -le $(wc -l < /tmp/kindle_folders.list 2>/dev/null) ]; then
+                    if [ "$dir_num" -le $(wc -l < $TMP_DIR/kindle_folders.list 2>/dev/null) ]; then
                         delete_directory "$dir_num"
                     else
                         echo "Invalid directory number"
@@ -127,10 +127,10 @@ list_local_books() {
             *)
                 if echo "$choice" | grep -qE '^[0-9]+$'; then
                     if [ "$choice" -ge 1 ] && [ "$choice" -le "$total_items" ]; then
-                        if [ "$choice" -le $(wc -l < /tmp/kindle_folders.list 2>/dev/null) ]; then
-                            current_dir=$(sed -n "${choice}p" /tmp/kindle_folders.list)
+                        if [ "$choice" -le $(wc -l < $TMP_DIR/kindle_folders.list 2>/dev/null) ]; then
+                            current_dir=$(sed -n "${choice}p" $TMP_DIR/kindle_folders.list)
                         else
-                            file_index=$((choice - $(wc -l < /tmp/kindle_folders.list 2>/dev/null)))
+                            file_index=$((choice - $(wc -l < $TMP_DIR/kindle_folders.list 2>/dev/null)))
                             delete_book "$file_index"
                         fi
                     else

--- a/kindlefetch/bin/misc.sh
+++ b/kindlefetch/bin/misc.sh
@@ -38,10 +38,10 @@ ensure_config_dir() {
 }
 
 cleanup() {
-    rm -f /tmp/kindle_books.list \
-          /tmp/kindle_folders.list \
-          /tmp/search_results.json \
-          /tmp/last_search_*
+    rm -f $TMP_DIR/kindle_books.list \
+          $TMP_DIR/kindle_folders.list \
+          $TMP_DIR/search_results.json \
+          $TMP_DIR/last_search_*
 }
 
 get_version() {

--- a/kindlefetch/bin/search.sh
+++ b/kindlefetch/bin/search.sh
@@ -82,11 +82,11 @@ search_books() {
     local has_next="false"
     [ "$page" -lt "$last_page" ] && has_next="true"
 
-    echo "$query" > /tmp/last_search_query
-    echo "$page" > /tmp/last_search_page
-    echo "$last_page" > /tmp/last_search_last_page
-    echo "$has_next" > /tmp/last_search_has_next
-    echo "$has_prev" > /tmp/last_search_has_prev
+    echo "$query" > $TMP_DIR/last_search_query
+    echo "$page" > $TMP_DIR/last_search_page
+    echo "$last_page" > $TMP_DIR/last_search_last_page
+    echo "$has_next" > $TMP_DIR/last_search_has_next
+    echo "$has_prev" > $TMP_DIR/last_search_has_prev
     
     local books=$(echo "$html_content" | awk '
         BEGIN {
@@ -176,15 +176,15 @@ search_books() {
         END { print "\n]" }
     ')
     
-    echo "$books" > /tmp/search_results.json
+    echo "$books" > $TMP_DIR/search_results.json
 
     while true; do
-        query=$(cat /tmp/last_search_query 2>/dev/null)
-        current_page=$(cat /tmp/last_search_page 2>/dev/null || echo 1)
-        last_page=$(cat /tmp/last_search_last_page 2>/dev/null || echo 1)
-        has_next=$(cat /tmp/last_search_has_next 2>/dev/null || echo "false")
-        has_prev=$(cat /tmp/last_search_has_prev 2>/dev/null || echo "false")
-        books=$(cat /tmp/search_results.json 2>/dev/null)
+        query=$(cat $TMP_DIR/last_search_query 2>/dev/null)
+        current_page=$(cat $TMP_DIR/last_search_page 2>/dev/null || echo 1)
+        last_page=$(cat $TMP_DIR/last_search_last_page 2>/dev/null || echo 1)
+        has_next=$(cat $TMP_DIR/last_search_has_next 2>/dev/null || echo "false")
+        has_prev=$(cat $TMP_DIR/last_search_has_prev 2>/dev/null || echo "false")
+        books=$(cat $TMP_DIR/search_results.json 2>/dev/null)
         count=$(echo "$books" | grep -o '"title":' | wc -l)
         
         display_books "$books" "$current_page" "$has_prev" "$has_next" "$last_page"
@@ -217,7 +217,7 @@ search_books() {
             *)
                 if echo "$choice" | grep -qE '^[0-9]+$'; then
                     if [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
-                        local book_info=$(awk -v i="$choice" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' /tmp/search_results.json)
+                        local book_info=$(awk -v i="$choice" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' $TMP_DIR/search_results.json)
 
                         local lgli_available=false
                         local zlib_available=false

--- a/kindlefetch/bin/settings.sh
+++ b/kindlefetch/bin/settings.sh
@@ -28,10 +28,10 @@ settings_menu() {
         
         case "$choice" in
             1)
-                echo -n "Enter your new Kindle downloads directory [It will be /mnt/us/your_directory. Only enter your_directory part.]: "
+                echo -n "Enter your new Kindle downloads directory [It will be $BASE_DIR/your_directory. Only enter your_directory part.]: "
                 read new_dir
                 if [ -n "$new_dir" ]; then
-                    KINDLE_DOCUMENTS="/mnt/us/$new_dir"
+                    KINDLE_DOCUMENTS="$BASE_DIR/$new_dir"
                     if [ ! -d "$KINDLE_DOCUMENTS" ]; then
                         mkdir -p "$KINDLE_DOCUMENTS" || {
                             echo "Error: Failed to create directory $KINDLE_DOCUMENTS" >&2

--- a/kindlefetch/bin/setup.sh
+++ b/kindlefetch/bin/setup.sh
@@ -17,10 +17,10 @@ first_time_setup() {
     echo "NOTE: This tool does not provide copyrighted material. You must configure your own book sources."
     echo ""
     
-    echo -n "Enter your Kindle downloads directory [It will be /mnt/us/your_directory. Only enter your_directory part.]: "
+    echo -n "Enter your Kindle downloads directory [It will be $BASE_DIR/your_directory. Only enter your_directory part.]: "
     read user_input
     if [ -n "$user_input" ]; then
-        KINDLE_DOCUMENTS="/mnt/us/$user_input"
+        KINDLE_DOCUMENTS="$BASE_DIR/$user_input"
         if [ ! -d "$KINDLE_DOCUMENTS" ]; then
             mkdir -p "$KINDLE_DOCUMENTS" || {
                 echo "Error: Failed to create directory $KINDLE_DOCUMENTS" >&2
@@ -28,7 +28,7 @@ first_time_setup() {
             }
         fi
     else
-        KINDLE_DOCUMENTS="/mnt/us/documents"
+        KINDLE_DOCUMENTS="$BASE_DIR/documents"
     fi
     echo -n "Create subfolders for books? [y/N]: "
     read subfolders_choice


### PR DESCRIPTION
This PR basically  just replaces usage of hardcoded `/mnt/us` and `/tmp` strings in file and directory paths (used by scripts in `bin/` directory) with `BASE_DIR` and `TMP_DIR` variables.

### Motivation for this changes:

By centralizing those values for 2 main needed directories (that act as base for various file paths in multiple scripts ) into variables defined at the top of the main script ( `bin/kindlefetch.sh`) the job of making  KindleFetch scripts run on other Linux environments besides Kindle OS is much esier. Users can simply remove or comment-out the IF block that checks if the script is running on a Kindle + change the 2 variables to set temp dir (chosen temp dir need to be created manually by the user :D ) and base dir for storing downloads.

Since there aren't any Kindle-only dependencies being use by this script / project (just curl, awk and sed :D ) this should be perfectly usable on many other non-Kindle devices and computers.


### How was this tested:

Tested on Kindle PW5 (both running from KUAL and manually via SSH) and tested on Android phone with Termux app.