### PR TITLE
Search page selection

### DIFF
--- a/kindlefetch/bin/search.sh
+++ b/kindlefetch/bin/search.sh
@@ -42,6 +42,7 @@ display_books() {
     if [ "$3" = "true" ]; then
         echo -n "p: Previous page | "
     fi
+    echo -n "t[1-$last_page]: Select page | "
     if [ "$4" = "true" ]; then
         echo -n "n: Next page | "
     fi
@@ -206,6 +207,25 @@ search_books() {
                     search_books "$query" "$new_page"
                 else
                     echo "Already on last page"
+                    sleep 2
+                fi
+                ;;
+            t[0-9]*)
+                page_number="${choice#t}"
+                if [[ "$page_number" =~ ^[0-9]+$ ]]; then
+                    if [ "$page_number" -ge 1 ] && [ "$page_number" -le "$last_page" ]; then
+                        if [ "$page_number" -ne "$current_page" ]; then
+                            search_books "$query" "$page_number"
+                        else
+                            echo "You are already on page $current_page"
+                            sleep 2
+                        fi
+                    else
+                        echo "Page number out of range (1-$last_page)"
+                        sleep 2
+                    fi
+                else
+                    echo "Invalid input"
                     sleep 2
                 fi
                 ;;


### PR DESCRIPTION
This pull request introduce the option to change pages on search direcly typing the page number (like in settings, using t+number). Useful when you have thousands of pages as a result of a search.