### PR TITLE
Harden provider flows: EPUB/PDF enforcement, mirror retries, and Z-Lib compatibility fixes

### DIFF
--- a/kindlefetch/bin/downloads/lgli_download.sh
+++ b/kindlefetch/bin/downloads/lgli_download.sh
@@ -8,15 +8,15 @@ lgli_download() {
         return 1
     fi
     
-    local book_info="$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' "$TMP_DIR"/search_results.json)"
-    if [ -z "$book_info" ]; then
-        echo "Invalid book selection"
+    local book_info="$(select_preferred_format_book_info "$index" "lgli")"
+    if [ $? -ne 0 ] || [ -z "$book_info" ]; then
+        echo "No EPUB/PDF version available from LibGen for this title."
         return 1
     fi
     
     local md5="$(get_json_value "$book_info" "md5")"
     local title="$(get_json_value "$book_info" "title")"
-    local format="$(get_json_value "$book_info" "format")"
+    local format="$(get_json_value "$book_info" "format" | tr '[:upper:]' '[:lower:]')"
     
     printf "\nDownloading: $title"
 

--- a/kindlefetch/bin/downloads/zlib_download.sh
+++ b/kindlefetch/bin/downloads/zlib_download.sh
@@ -8,18 +8,41 @@ zlib_download() {
         return 1
     fi
     
-    local book_info="$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' "$TMP_DIR"/search_results.json)"
-    if [ -z "$book_info" ]; then
-        echo "Invalid book selection" >&2
+    local book_info="$(select_preferred_format_book_info "$index" "zlib")"
+    if [ $? -ne 0 ] || [ -z "$book_info" ]; then
+        echo "No EPUB/PDF version available from Z-Library for this title." >&2
         return 1
     fi
     
     local md5="$(get_json_value "$book_info" "md5")"
+    local book_page=""
 
     local final_url="$(curl -s -L -o /dev/null -w "%{url_effective}" "$ZLIB_URL/md5/$md5")"
 
-    local book_id="$(echo "$final_url" | sed -n 's#.*/book/\([0-9][0-9]*\)/[a-z0-9]\+#\1#p')"
-    local book_hash="$(echo "$final_url" | sed -n 's#.*/book/[0-9][0-9]*/\([a-z0-9]\+\).*#\1#p')"
+    # Legacy: /book/<id>/<hash>
+    local book_id="$(echo "$final_url" | sed -n 's#.*/book/\([0-9][0-9]*\)/[[:alnum:]]\+\(/.*\)\?$#\1#p')"
+    local book_hash="$(echo "$final_url" | sed -n 's#.*/book/[0-9][0-9]*/\([[:alnum:]]\+\)\(/.*\)\?$#\1#p')"
+
+    # Current format: /book/<hash>
+    if [ -z "$book_hash" ]; then
+        book_hash="$(echo "$final_url" | sed -n 's#.*/book/\([[:alnum:]]\+\)\(/.*\)\?$#\1#p')"
+    fi
+
+    if [ -n "$book_hash" ]; then
+        book_page="$(curl -s -L -b "$ZLIB_COOKIES_FILE" "$ZLIB_URL/book/$book_hash")"
+        if echo "$book_page" | grep -qi "isn't available for download due to the complaint of the copyright holder"; then
+            echo "This title is currently unavailable on Z-Library (copyright complaint)." >&2
+            return 1
+        fi
+    fi
+
+    # If URL does not contain numeric id, fetch page and extract it.
+    if [ -z "$book_id" ] && [ -n "$book_hash" ]; then
+        book_id="$(echo "$book_page" | sed -n 's/.*data-book_id="\([0-9][0-9]*\)".*/\1/p' | head -n1)"
+        if [ -z "$book_id" ]; then
+            book_id="$(echo "$book_page" | sed -n 's/.*CurrentBook = new Book({\"id\":\([0-9][0-9]*\).*/\1/p' | head -n1)"
+        fi
+    fi
 
     if [ -z "$book_id" ] || [ -z "$book_hash" ]; then
         echo "Failed to extract book info from URL: $final_url" >&2
@@ -34,6 +57,31 @@ zlib_download() {
     local ddl="$(get_json_value "$response" "downloadLink" | sed 's#\\\/#/#g' | tr -d '\r\n')"
     local title="$(get_json_value "$response" "description" | tr -d '\r\n')"
     local ext="$(get_json_value "$response" "extension" | tr -d '\r\n')"
+
+    if [ -z "$title" ] || [ "$title" = "null" ]; then
+        title="$(get_json_value "$book_info" "title" | tr -d '\r\n')"
+    fi
+
+    if [ -z "$ext" ] || [ "$ext" = "null" ]; then
+        ext="$(get_json_value "$book_info" "format" | tr '[:upper:]' '[:lower:]' | tr -d '\r\n')"
+    fi
+
+    if [ -z "$ddl" ]; then
+        if [ -z "$book_page" ] || ! echo "$book_page" | grep -q "addDownloadedBook"; then
+            book_page="$(curl -s -L -b "$ZLIB_COOKIES_FILE" "$ZLIB_URL/book/$book_hash")"
+        fi
+        local dl_path="$(echo "$book_page" | sed -n 's#.*class="btn btn-default addDownloadedBook" href="\([^"]*\)".*#\1#p' | head -n1)"
+        if [ -n "$dl_path" ]; then
+            case "$dl_path" in
+                http://*|https://*)
+                    ddl="$dl_path"
+                    ;;
+                *)
+                    ddl="$ZLIB_URL$dl_path"
+                    ;;
+            esac
+        fi
+    fi
 
     if [ -z "$ddl" ]; then
         echo "Failed to get download link from Z-Library response." >&2
@@ -56,6 +104,7 @@ zlib_download() {
     fi
 
     local file_size="$(curl -sI "$ddl" | awk '/Content-Length/ {printf "%.2f MB\n", $2/1048576}')"
+    [ -z "$ext" ] && ext="bin"
     local filename="$(sanitize_filename "${title}.${ext}")"
     local filename="${filename:-book.bin}"
     

--- a/kindlefetch/bin/misc.sh
+++ b/kindlefetch/bin/misc.sh
@@ -38,6 +38,10 @@ sanitize_filename() {
     echo "$1" | sed -e 's/[^[:alnum:]\._-]/_/g' -e 's/ /_/g'
 }
 
+normalize_title() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]//g'
+}
+
 get_json_value() {
     echo "$1" | grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | sed "s/\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\"/\1/" || \
     echo "$1" | grep -o "\"$2\"[[:space:]]*:[[:space:]]*[^,}]*" | sed "s/\"$2\"[[:space:]]*:[[:space:]]*\([^,}]*\)/\1/"
@@ -131,14 +135,120 @@ zlib_login() {
 
 find_working_url() {
     for url in "$@"; do
-        code=$(curl -s -o /dev/null -w '%{http_code}' \
-               --max-time 2 -L "$url")
+        attempt=1
+        while [ "$attempt" -le 5 ]; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+                   --max-time 10 -L "$url")
+            curl_status=$?
 
-        [ "$code" = "000" ] && continue
-        [ "$code" -ge 500 ] && continue
+            if [ "$curl_status" -eq 0 ] && [ "$code" != "000" ] && [ "$code" -lt 500 ]; then
+                echo "$url"
+                return 0
+            fi
 
-        echo "$url"
-        return 0
+            attempt=$((attempt + 1))
+            [ "$attempt" -le 5 ] && sleep 1
+        done
     done
+    return 1
+}
+
+zlib_md5_is_downloadable() {
+    local md5="$1"
+    local cache_file="${TMP_DIR}/zlib_availability.cache"
+    local cached_status=""
+    local final_url=""
+    local book_hash=""
+    local book_page=""
+
+    [ -z "$md5" ] && return 0
+
+    if [ -f "$cache_file" ]; then
+        cached_status="$(awk -F'|' -v m="$md5" '$1 == m {print $2; exit}' "$cache_file")"
+        case "$cached_status" in
+            ok) return 0 ;;
+            blocked) return 1 ;;
+        esac
+    fi
+
+    final_url="$(curl -s -L -o /dev/null -w "%{url_effective}" "$ZLIB_URL/md5/$md5")"
+    book_hash="$(echo "$final_url" | sed -n 's#.*/book/\([[:alnum:]]\+\)\(/.*\)\?$#\1#p')"
+
+    if [ -z "$book_hash" ]; then
+        echo "$md5|ok" >> "$cache_file"
+        return 0
+    fi
+
+    if [ -f "$ZLIB_COOKIES_FILE" ]; then
+        book_page="$(curl -s -L -b "$ZLIB_COOKIES_FILE" "$ZLIB_URL/book/$book_hash")"
+    else
+        book_page="$(curl -s -L "$ZLIB_URL/book/$book_hash")"
+    fi
+
+    if echo "$book_page" | grep -qi "isn't available for download due to the complaint of the copyright holder"; then
+        echo "$md5|blocked" >> "$cache_file"
+        return 1
+    fi
+
+    echo "$md5|ok" >> "$cache_file"
+    return 0
+}
+
+select_preferred_format_book_info() {
+    local index="$1"
+    local provider="$2"
+
+    if [ ! -f "$TMP_DIR/search_results.json" ]; then
+        return 1
+    fi
+
+    local selected_book_info="$(awk -v i="$index" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' "$TMP_DIR"/search_results.json)"
+    if [ -z "$selected_book_info" ]; then
+        return 1
+    fi
+
+    local selected_title="$(get_json_value "$selected_book_info" "title")"
+    local selected_key="$(normalize_title "$selected_title")"
+
+    local total_books="$(grep -o '"title":' "$TMP_DIR"/search_results.json | wc -l)"
+    local preferred_pdf=""
+    local i=1
+
+    while [ "$i" -le "$total_books" ]; do
+        local candidate="$(awk -v i="$i" 'BEGIN{RS="\\{"; FS="\\}"} NR==i+1{print $1}' "$TMP_DIR"/search_results.json)"
+        if [ -n "$candidate" ]; then
+            local candidate_description="$(get_json_value "$candidate" "description" | tr '[:upper:]' '[:lower:]')"
+            if echo "$candidate_description" | grep -q "$provider"; then
+                local candidate_title="$(get_json_value "$candidate" "title")"
+                local candidate_key="$(normalize_title "$candidate_title")"
+                if [ "$candidate_key" = "$selected_key" ]; then
+                    local candidate_md5="$(get_json_value "$candidate" "md5")"
+                    if [ "$provider" = "zlib" ]; then
+                        if ! zlib_md5_is_downloadable "$candidate_md5"; then
+                            i=$((i + 1))
+                            continue
+                        fi
+                    fi
+                    local candidate_format="$(get_json_value "$candidate" "format" | tr '[:upper:]' '[:lower:]')"
+                    case "$candidate_format" in
+                        epub)
+                            echo "$candidate"
+                            return 0
+                            ;;
+                        pdf)
+                            [ -z "$preferred_pdf" ] && preferred_pdf="$candidate"
+                            ;;
+                    esac
+                fi
+            fi
+        fi
+        i=$((i + 1))
+    done
+
+    if [ -n "$preferred_pdf" ]; then
+        echo "$preferred_pdf"
+        return 0
+    fi
+
     return 1
 }

--- a/kindlefetch/bin/search.sh
+++ b/kindlefetch/bin/search.sh
@@ -173,7 +173,8 @@ search_books() {
             gsub(/"/, "\\\"", author)
             gsub(/"/, "\\\"", description)
         
-            if (title != "") {
+            format_lc = tolower(format)
+            if (title != "" && (format_lc == "epub" || format_lc == "pdf")) {
                 if (count > 0) {
                     printf ",\n"
                 }
@@ -274,12 +275,18 @@ search_books() {
 
                         local lgli_available=false
                         local zlib_available=false
+                        local zlib_unavailable_note=false
 
                         if echo "$book_info" | grep -q "lgli"; then
                             lgli_available=true
                         fi
                         if echo "$book_info" | grep -q "zlib"; then
-                            zlib_available=true
+                            if select_preferred_format_book_info "$choice" "zlib" >/dev/null; then
+                                zlib_available=true
+                            else
+                                zlib_available=false
+                                zlib_unavailable_note=true
+                            fi
                         fi
 
                         while true; do
@@ -296,6 +303,8 @@ search_books() {
                                 else
                                     echo "2. zlib (Authentication required)"
                                 fi
+                            elif [ "$zlib_unavailable_note" = true ]; then
+                                echo "   zlib unavailable for this title (blocked or no EPUB/PDF copy)"
                             fi
                             echo "3. Cancel download"
 


### PR DESCRIPTION
## Summary
This PR hardens KindleFetch search/download behavior across Anna's Archive, LibGen, and Z-Library, with a focus on reliability and avoiding dead-end results.

Main goals:
- enforce preferred download formats (`EPUB`, fallback `PDF`)
- reduce connection flakiness during mirror probing
- handle current Z-Library URL/API behavior changes
- avoid presenting Z-Lib options that are known to be blocked/unusable

## Problems Observed
### 1) Mirror/connectivity false negatives
`find_working_url()` used a very short timeout and no retries, causing intermittent "failed to connect" outcomes on slower Kindle network conditions.

### 2) Inconsistent/undesired formats
Search and download flows could still select non-preferred formats (e.g. AZW3), despite user intent to prioritize EPUB/PDF.

### 3) Z-Library flow regressions
Recent Z-Lib behavior differs from older assumptions:
- redirects commonly use `/book/<hash>` (not always `/book/<id>/<hash>`)
- hashes may be mixed-case
- `eapi/book/<id>/<hash>/file` can return `Invalid hash` for some entries even when logged in
- some books are visible but blocked from download due to copyright complaints

This produced opaque failures in KindleFetch (e.g. generic `Invalid hash`).

## What Changed
### A) Core helper improvements (`kindlefetch/bin/misc.sh`)
- Added retries + longer timeout in `find_working_url()`:
  - up to 5 attempts
  - 10-second timeout
  - short delay between retries
- Added `normalize_title()` for stable same-title matching.
- Added `select_preferred_format_book_info()`:
  - for a selected result/title/provider, choose `EPUB` first, then `PDF`
  - return no candidate if neither exists
- Added `zlib_md5_is_downloadable()` with cache (`$TMP_DIR/zlib_availability.cache`):
  - probes Z-Lib entry by md5
  - detects copyright-complaint blocked pages
  - caches blocked/ok decisions to avoid repeated network checks

### B) Search filtering and source gating (`kindlefetch/bin/search.sh`)
- Filter parsed Anna's results to **EPUB/PDF only** before presenting list entries.
- At source selection time:
  - only expose zlib when a valid EPUB/PDF candidate exists and is not known blocked
  - otherwise show an explicit note that zlib is unavailable for that title

### C) LibGen downloader updates (`kindlefetch/bin/downloads/lgli_download.sh`)
- Resolve selected item through provider-aware format preference helper.
- Return clear message when no LibGen EPUB/PDF variant exists.
- Normalize output extension casing.

### D) Z-Library downloader hardening (`kindlefetch/bin/downloads/zlib_download.sh`)
- Support both URL layouts:
  - legacy `/book/<id>/<hash>`
  - current `/book/<hash>`
- Accept mixed-case hashes.
- Extract missing numeric `book_id` from page HTML when needed.
- If API `downloadLink` is missing/invalid, fallback to HTML `/dl/...` extraction.
- Add explicit detection/message for copyright-complaint blocked entries.
- Improve title/extension fallback behavior when API fields are missing.

## Why This Approach
- Keeps behavior aligned with user-facing expectation: EPUB first, then PDF.
- Moves volatile provider-specific checks into reusable helpers to reduce duplicated logic.
- Handles provider drift (especially Z-Lib) without requiring user intervention.
- Replaces ambiguous errors with actionable messages.

## Validation Performed
- Shell syntax checks on modified scripts.
- Real on-device Kindle tests over SSH:
  - Anna search parsing/output
  - LibGen download success path
  - Z-Lib success path
  - Z-Lib blocked/copyright complaint path
  - previously failing `Invalid hash` case now handled more explicitly
- Regression checks for search/source menu behavior after gating logic.

## User-Visible Behavior Changes
- Search result list excludes non-EPUB/PDF entries.
- Downloader refuses titles without EPUB/PDF variants (instead of silently taking AZW3).
- Z-Lib source may be hidden for titles known to be blocked/unusable.
- Error messages are more specific for blocked Z-Lib items.

## Files Changed
- `kindlefetch/bin/misc.sh`
- `kindlefetch/bin/search.sh`
- `kindlefetch/bin/downloads/lgli_download.sh`
- `kindlefetch/bin/downloads/zlib_download.sh`
